### PR TITLE
Use canonical workspace name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,1 @@
-workspace(name = "bazel_gomock")
+workspace(name = "com_github_jmhodges_bazel_gomock")


### PR DESCRIPTION
to follow bazel's advice: 
Bazel [...] advises that a WORKSPACE call itself the reverse of the "canonical" URL of that repository, like com_example_foo_utils.
See, https://docs.google.com/document/d/1qPOUeoqDA3eWFFXS1shWX1FT3e4BQB8yuSMrfQL4QrA/edit#heading=h.1kkuneerfl14