### PR TITLE
Unbreak gomock() in combination with remote builds

### DIFF
--- a/gomock.bzl
+++ b/gomock.bzl
@@ -7,7 +7,10 @@ def _gomock_sh_impl(ctx):
     go_ctx = go_context(ctx)
     gopath = "$(pwd)/" + ctx.var["BINDIR"] + "/" + ctx.attr.gopath_dep[GoPath].gopath
 
-    inputs = [ctx.file.mockgen_tool, go_ctx.go] + ctx.attr.gopath_dep.files.to_list()
+    inputs = [ctx.file.mockgen_tool, go_ctx.go] + (
+        ctx.attr.gopath_dep.files.to_list() +
+        go_ctx.sdk.headers + go_ctx.sdk.srcs + go_ctx.sdk.tools
+    )
     args = []
     if ctx.attr.package != "":
         args += ["-package", ctx.attr.package]

--- a/gomock.bzl
+++ b/gomock.bzl
@@ -1,19 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_path", "go_rule")
-
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
 
 _MOCKGEN_TOOL = "@com_github_golang_mock//mockgen"
-        
+
 def _gomock_sh_impl(ctx):
     go_ctx = go_context(ctx)
     gopath = "$(pwd)/" + ctx.var["BINDIR"] + "/" + ctx.attr.gopath_dep[GoPath].gopath
 
     inputs = [ctx.file.mockgen_tool, go_ctx.go] + ctx.attr.gopath_dep.files.to_list()
     args = []
-    if ctx.attr.package != '':
+    if ctx.attr.package != "":
         args += ["-package", ctx.attr.package]
 
-    args += ["-destination", "$(pwd)/"+ ctx.outputs.out.path]
+    args += ["-destination", "$(pwd)/" + ctx.outputs.out.path]
 
     if ctx.attr.source == None:
         args += [ctx.attr.library[GoLibrary].importpath]
@@ -34,11 +33,11 @@ def _gomock_sh_impl(ctx):
            export GOPATH={gopath} &&
            {mockgen} {args}
         """.format(
-            godir=go_ctx.go.path[:-1-len(go_ctx.go.basename)],
-            gopath=gopath,
-            mockgen="$(pwd)/"+ctx.file.mockgen_tool.path,
-            args = " ".join(args)
-        )
+            godir = go_ctx.go.path[:-1 - len(go_ctx.go.basename)],
+            gopath = gopath,
+            mockgen = "$(pwd)/" + ctx.file.mockgen_tool.path,
+            args = " ".join(args),
+        ),
     )
 
 _gomock_sh = go_rule(
@@ -49,18 +48,15 @@ _gomock_sh = go_rule(
             providers = [GoLibrary],
             mandatory = True,
         ),
-
         "source": attr.label(
             doc = "A Go source file to find all the interfaces to generate mocks for. See also the docs for library.",
             mandatory = False,
             allow_single_file = True,
         ),
-
         "out": attr.output(
             doc = "The new Go file to emit the generated mocks into",
-            mandatory = True
+            mandatory = True,
         ),
-    
         "interfaces": attr.string_list(
             allow_empty = False,
             doc = "The names of the Go interfaces to generate mocks for. If not set, all of the interfaces in the library or source file will have mocks generated for them.",
@@ -69,13 +65,11 @@ _gomock_sh = go_rule(
         "package": attr.string(
             doc = "The name of the package the generated mocks should be in. If not specified, uses mockgen's default.",
         ),
-
         "gopath_dep": attr.label(
             doc = "The go_path label to use to create the GOPATH for the given library. Will be set correctly by the gomock macro, so you don't need to set it.",
-            providers=[GoPath],
+            providers = [GoPath],
             mandatory = False,
         ),
-
         "mockgen_tool": attr.label(
             doc = "The mockgen tool to run",
             default = Label(_MOCKGEN_TOOL),
@@ -94,7 +88,7 @@ def gomock(name, library, out, **kwargs):
         mockgen_tool = kwargs["mockgen_tool"]
     go_path(
         name = gopath_name,
-        deps = [library, mockgen_tool]
+        deps = [library, mockgen_tool],
     )
 
     _gomock_sh(


### PR DESCRIPTION
The attached changes make gomock() work when used in projects that are built against a remote buildfarm. Some of the input file dependencies were missing in that case.