### PR TITLE
Support source mode without go.mod file

### DIFF
--- a/gomock.bzl
+++ b/gomock.bzl
@@ -28,6 +28,8 @@ def _gomock_source_impl(ctx):
            source <($PWD/{godir}/go env) &&
            export PATH=$GOROOT/bin:$PWD/{godir}:$PATH &&
            export GOPACKAGESPRINTGOLISTERRORS=true &&
+           export HOME=$PWD &&
+           (test -f go.mod || echo "module fakemod" > go.mod) &&
            mkdir -p bazel-out/_tmp/go-cache &&
            export GOCACHE=$PWD/bazel-out/_tmp/go-cache &&
            {cmd} {args} > {out}

--- a/gomock.bzl
+++ b/gomock.bzl
@@ -27,6 +27,9 @@ def _gomock_source_impl(ctx):
         command = """
            source <($PWD/{godir}/go env) &&
            export PATH=$GOROOT/bin:$PWD/{godir}:$PATH &&
+           export GOPACKAGESPRINTGOLISTERRORS=true &&
+           mkdir -p bazel-out/_tmp/go-cache &&
+           export GOCACHE=$PWD/bazel-out/_tmp/go-cache &&
            {cmd} {args} > {out}
         """.format(
             godir = go_ctx.go.path[:-1 - len(go_ctx.go.basename)],


### PR DESCRIPTION
Debugging #17, after setting `export GOPACKAGESPRINTGOLISTERRORS=true`, I got the following message:

```
GOROOT=/private/var/tmp/_bazel_zplin/1b23f78923ad6c0028e8aab1a0a6d5fb/sandbox/darwin-sandbox/1/execroot/__main__/external/go_sdk GOPATH= GO111MODULE= PWD=/private/var/tmp/_bazel_zplin/1b23f78923ad6c0028e8aab1a0a6d5fb/sandbox/darwin-sandbox/1/execroot/__main__ go [list -f {{context.GOARCH}} {{context.Compiler}} -- unsafe] stderr: <<build cache is disabled by GOCACHE=off, but required as of Go 1.12
>>
2019/05/30 22:50:09 Loading input failed: could not determine GOARCH and Go compiler
```

Setting `GOCACHE` fixed the error. Then both `go list` and `go env` complained about `missing $GOPATH`, similar to https://github.com/golang/go/issues/27468#issuecomment-455358031. Since we no longer have GOPATH, we need to set `HOME` instead. Then mockgen complained about `Loading input failed: loading package failed`. Creating a `go.mod` file if it doesn't exist fixed that error.

Together with https://github.com/golang/mock/pull/299, I am finally able to build https://github.com/linzhp/bazel_examples/tree/af8f36c2d268f510d423bd8ea0410266da0da224/gomock