### PR TITLE
Switch mockgen from inputs to tools

### DIFF
--- a/gomock.bzl
+++ b/gomock.bzl
@@ -140,7 +140,7 @@ def _gomock_prog_gen_impl(ctx):
     out = ctx.outputs.out
     ctx.actions.run_shell(
         outputs = [out],
-        inputs = [cmd],
+        tools = [cmd],
         command = """
            {cmd} {args} > {out}
         """.format(


### PR DESCRIPTION
Using Bazel 0.27, using inputs from tools is deprecated and results in errors such as:

```
	File "/Users/mcarl/dev/perso/bb-storage/internal/mock/BUILD.bazel", line 25
		_gomock_prog_gen(name = 'remoteexecution_gomock_prog')
	File "/private/var/tmp/_bazel_mcarl/d2366be62be4ea32485058980e219d7c/external/bazel_gomock/gomock.bzl", line 141, in _gomock_prog_gen_impl
		ctx.actions.run_shell(outputs = [out], inputs = [cmd], com...))
Found tool(s) 'bazel-out/host/bin/external/com_github_golang_mock/mockgen/darwin_amd64_stripped/mockgen' in inputs. A tool is an input with executable=True set. All tools should be passed using the 'tools' argument instead of 'inputs' in order to make their runfiles available to the action. This safety check will not be performed once the action is modified to take a 'tools' argument. To temporarily disable this check, set --incompatible_no_support_tools_in_action_inputs=false.
```

This fixes this issue.