### PR TITLE
Remove interfaces attribute from source mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ file with the interfaces you want in it.
 |------|---------------|------|---------------|
 | name | | string | The name of the target. (Required.) |
 | library| | Label | The go_library to find the interfaces in. (Required.) |
-| interfaces | | list of string | The names of interfaces in `library` to generate mocks for. (Required.) |
+| interfaces | | list of string | The names of interfaces in `library` to generate mocks for. (Required when `source` is not provided) |
+| source | | string | The Go source file that contains interfaces to be mocked. See the gomock documentation on `-source` for more information. |
 | out | | string | The file name to give the generated output. (Required.) |
 | package | | string | The package name to use in the generated output. See the gomock documentation on `-package` for more information. |
-| imports | | string\_dict | Dictionary of keys of package names and values of import paths to use the keys as the identifier to use when the generated output uses the given import path. See the gomock documentation on `-imports` for more information. | 
+| imports | | string\_dict | Dictionary of keys of package names and values of import paths to use the keys as the identifier to use when the generated output uses the given import path. See the gomock documentation on `-imports` for more information. |
 | self\_package | |  string | The full import path for the generated code. See the gomock documentation on `-self_package` for more information. |
 | mock\_names | | string\_dict | Dictionary of interface name to mock name pairs to change the output names of the mock objects. Mock names default to 'Mock' prepended to the name of the interface. See the gomock documentation on `-mock_names` for more information. |
 | copyright\_file | | Label | The file containing the copyright to prepend to the generated output. See the gomock documentation on `-copyright_file` for more information. |

--- a/gomock.bzl
+++ b/gomock.bzl
@@ -21,8 +21,6 @@ def _gomock_source_impl(ctx):
                 aux_files.append("{0}={1}".format(pkg, mapped_f))
         args += ["-aux_files", ",".join(aux_files)]
 
-    args += [",".join(ctx.attr.interfaces)]
-
     inputs = (
         ctx.attr.gopath_dep.files.to_list() + needed_files +
         go_ctx.sdk.headers + go_ctx.sdk.srcs + go_ctx.sdk.tools
@@ -72,11 +70,6 @@ _gomock_source = go_rule(
         ),
         "out": attr.output(
             doc = "The new Go file to emit the generated mocks into",
-            mandatory = True,
-        ),
-        "interfaces": attr.string_list(
-            allow_empty = False,
-            doc = "The names of the Go interfaces to generate mocks for. If not set, all of the interfaces in the library or source file will have mocks generated for them.",
             mandatory = True,
         ),
 	"aux_files": attr.string_list_dict(


### PR DESCRIPTION
When mockgen is running in source mode, it always generate mocks for all interfaces in the source file, regardless of interfaces are provided in the argument. In fact, it doesn't need that argument. Bazel gomock rule should not require `interfaces` attribute either.