### PR TITLE
Removing GOPATH in source mode

### DIFF
--- a/gomock.bzl
+++ b/gomock.bzl
@@ -1,28 +1,27 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_path")
-load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context")
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary")
 
 _MOCKGEN_TOOL = "@com_github_golang_mock//mockgen"
 _MOCKGEN_MODEL_LIB = "@com_github_golang_mock//mockgen/model:go_default_library"
 
 def _gomock_source_impl(ctx):
     go_ctx = go_context(ctx)
-    gopath = "$(pwd)/" + ctx.bin_dir.path + "/" + ctx.attr.gopath_dep[GoPath].gopath
 
     # passed in source needs to be in gopath to not trigger module mode
-    args = ["-source", gopath + "/src/" + ctx.attr.library[GoLibrary].importmap + "/"+ ctx.file.source.basename]
+    args = ["-source", ctx.file.source.path]
 
     args, needed_files = _handle_shared_args(ctx, args)
 
     if len(ctx.attr.aux_files) > 0:
         aux_files = []
-        for pkg, files in ctx.attr.aux_files.items():
-            for f in files:
-                mapped_f = gopath + "/src/" + ctx.attr.library[GoLibrary].importmap + "/"+ f
-                aux_files.append("{0}={1}".format(pkg, mapped_f))
+        for target, pkg in ctx.attr.aux_files.items():
+            f = target.files.to_list()[0]
+            aux_files.append("{0}={1}".format(pkg, f.path))
+            needed_files.append(f)
         args += ["-aux_files", ",".join(aux_files)]
 
     inputs = (
-        ctx.attr.gopath_dep.files.to_list() + needed_files +
+        needed_files +
         go_ctx.sdk.headers + go_ctx.sdk.srcs + go_ctx.sdk.tools
     ) + [ctx.file.source]
 
@@ -36,22 +35,17 @@ def _gomock_source_impl(ctx):
             go_ctx.go,
         ],
         command = """
-           source <($PWD/{godir}/go env) &&
-           export PATH=$GOROOT/bin:$PWD/{godir}:$PATH &&
-           export GOPATH={gopath} &&
-           mkdir -p .gocache &&
-           export GOCACHE=$PWD/.gocache &&
+            export GOPATH=$PWD
            {cmd} {args} > {out}
         """.format(
-            godir = go_ctx.go.path[:-1 - len(go_ctx.go.basename)],
-            gopath = gopath,
             cmd = "$(pwd)/" + ctx.file.mockgen_tool.path,
             args = " ".join(args),
             out = ctx.outputs.out.path,
             mnemonic = "GoMockSourceGen",
         ),
         env = {
-            "GO111MODULE": "off",  # explicitly relying on passed in go_path to not download modules while doing codegen
+            # GOCACHE is required starting in Go 1.12
+            "GOCACHE": "./.gocache",
         },
     )
 
@@ -77,9 +71,10 @@ _gomock_source = rule(
             doc = "Ignored. If `source` is not set, this would be the list of Go interfaces to generate mocks for.",
             mandatory = True,
         ),
-	"aux_files": attr.string_list_dict(
+        "aux_files": attr.label_keyed_string_dict(
             default = {},
-            doc = "A map from packages to auxilliary Go source files to load for those packages.",
+            doc = "A map auxilliary Go source files to their packages.",
+            allow_files = True,
         ),
         "package": attr.string(
             doc = "The name of the package the generated mocks should be in. If not specified, uses mockgen's default.",
@@ -97,11 +92,6 @@ _gomock_source = rule(
         "copyright_file": attr.label(
             doc = "Optional file containing copyright to prepend to the generated contents.",
             allow_single_file = True,
-            mandatory = False,
-        ),
-        "gopath_dep": attr.label(
-            doc = "The go_path label to use to create the GOPATH for the given library. Will be set correctly by the gomock macro, so you don't need to set it.",
-            providers = [GoPath],
             mandatory = False,
         ),
         "mockgen_tool": attr.label(
@@ -125,15 +115,9 @@ def gomock(name, library, out, **kwargs):
         mockgen_tool = kwargs["mockgen_tool"]
 
     if kwargs.get("source", None):
-        gopath_name = name + "_gomock_gopath"
-        go_path(
-            name = gopath_name,
-            deps = [library, mockgen_tool],
-        )
         _gomock_source(
             name = name,
             library = library,
-            gopath_dep = gopath_name,
             out = out,
             **kwargs)
     else:


### PR DESCRIPTION
After https://github.com/golang/mock/pull/420, GoMock source mode no longer requires full transitive dependency closure in GOPATH. As a result, the gomock rule can avoid calling the `gopath` rule, it only need to make sure the source file and auxiliary files in the GOPATH.

When building `//gomock:mocks` from https://github.com/linzhp/bazel_examples/commit/b7f4b75098d22e604540a87e4eaa3877de46aa9d, bazel_gomock (4f2ee840432b1a08ccc46ee4f2c1f5a2bad8fade) spent 2.287 seconds on gomock rule:

```
     538 ms    5.71%   action 'GoPath gomock/mocks_gomock_gopath'
    1.749 s   18.57%   action 'Action gomock/mocks.go'
```

After applying this patch, it became 1.498 seconds:

```
    1.498 s   20.77%   action 'Action gomock/mocks.go'
```

The difference would be more significant for packages with large dependency tree