### PR TITLE
updated deprecated go_rule

### DIFF
--- a/gomock.bzl
+++ b/gomock.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_path", "go_rule")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_path")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoLibrary", "GoPath")
 
 _MOCKGEN_TOOL = "@com_github_golang_mock//mockgen"
@@ -55,7 +55,7 @@ def _gomock_source_impl(ctx):
         },
     )
 
-_gomock_source = go_rule(
+_gomock_source = rule(
     _gomock_source_impl,
     attrs = {
         "library": attr.label(
@@ -186,7 +186,7 @@ def _gomock_prog_gen_impl(ctx):
         mnemonic = "GoMockReflectProgOnlyGen"
     )
 
-_gomock_prog_gen = go_rule(
+_gomock_prog_gen = rule(
     _gomock_prog_gen_impl,
     attrs = {
         "library": attr.label(
@@ -239,7 +239,7 @@ def _gomock_prog_exec_impl(ctx):
         mnemonic = "GoMockReflectExecOnlyGen",
     )
 
-_gomock_prog_exec = go_rule(
+_gomock_prog_exec = rule(
     _gomock_prog_exec_impl,
     attrs = {
         "library": attr.label(


### PR DESCRIPTION
The released version of `bazel_gomock` was using the deprecated `go_rule` method. Fixed and tested.