### PR TITLE
bring back but ignore interfaces on gomock_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ file with the interfaces you want in it.
 |------|---------------|------|---------------|
 | name | | string | The name of the target. (Required.) |
 | library| | Label | The go_library to find the interfaces in. (Required.) |
-| interfaces | | list of string | The names of interfaces in `library` to generate mocks for. (Required when `source` is not provided) |
-| source | | string | The Go source file that contains interfaces to be mocked. See the gomock documentation on `-source` for more information. |
+| interfaces | | list of string | The names of interfaces in `library` to generate mocks for. (Required if `source` is not set, and ignored if `source` is set.) |
+| source | | string | Prefer using `library` only, instead of using this argument. The Go source file to generate interfaces from. If this is set, `interfaces` is ignored because `mockgen` will always generate code for all interfaces. See the gomock documentation on `-source` for more information. |
 | out | | string | The file name to give the generated output. (Required.) |
 | package | | string | The package name to use in the generated output. See the gomock documentation on `-package` for more information. |
 | imports | | string\_dict | Dictionary of keys of package names and values of import paths to use the keys as the identifier to use when the generated output uses the given import path. See the gomock documentation on `-imports` for more information. |

--- a/gomock.bzl
+++ b/gomock.bzl
@@ -72,6 +72,11 @@ _gomock_source = rule(
             doc = "The new Go file to emit the generated mocks into",
             mandatory = True,
         ),
+        "interfaces": attr.string_list(
+            allow_empty = False,
+            doc = "Ignored. If `source` is not set, this would be the list of Go interfaces to generate mocks for.",
+            mandatory = True,
+        ),
 	"aux_files": attr.string_list_dict(
             default = {},
             doc = "A map from packages to auxilliary Go source files to load for those packages.",


### PR DESCRIPTION
This fixes an old API break. It also adds some documentation to the
`source` argument.