### PR TITLE
Making interfaces optional in source mode

### DIFF
--- a/gomock.bzl
+++ b/gomock.bzl
@@ -75,7 +75,7 @@ _gomock_source = rule(
         "interfaces": attr.string_list(
             allow_empty = False,
             doc = "Ignored. If `source` is not set, this would be the list of Go interfaces to generate mocks for.",
-            mandatory = True,
+            mandatory = False,
         ),
 	"aux_files": attr.string_list_dict(
             default = {},

--- a/gomock.bzl
+++ b/gomock.bzl
@@ -73,7 +73,7 @@ _gomock_source = rule(
             mandatory = True,
         ),
         "interfaces": attr.string_list(
-            allow_empty = False,
+            allow_empty = True,
             doc = "Ignored. If `source` is not set, this would be the list of Go interfaces to generate mocks for.",
             mandatory = False,
         ),


### PR DESCRIPTION
Sorry for breaking the API in #42. I understand it's needed for backward compatibility. As it is going to be ignored, can we make it optional so new code doesn't have to specify `interfaces`?